### PR TITLE
Remove no-class_parameter_defaults-check

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -25,7 +25,6 @@ do
             --no-80chars-check \
             --no-autoloader_layout-check \
             --no-nested_classes_or_defines-check \
-            --no-class_parameter_defaults-check \
             --with-filename $file
  
         # Set us up to bail if we receive any syntax errors


### PR DESCRIPTION
puppet-lint no longer implements the class_parameter_defaults check, so this option is invalid.
