### PR TITLE
Disabling check for inherits params

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -25,6 +25,7 @@ do
             --no-80chars-check \
             --no-autoloader_layout-check \
             --no-nested_classes_or_defines-check \
+            --no-class_inherits_from_params_class-check \
             --with-filename $file
 
         # Set us up to bail if we receive any syntax errors


### PR DESCRIPTION
Disabling check for inherits since it's commonly used and only not compatible with Puppet 2.6.2 and earlier.
