### PR TITLE
Only test the catalog if one exists.

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -60,14 +60,17 @@ do
 done
 echo ""
 
-echo "### Checking if the catalog compiles"
-puppet apply --noop manifests/site.pp
-if [[ $? -ne 0 ]]
+if [[ -f manifests/site.pp ]]
 then
-    echo "ERROR: puppet catalog compilation failed"
-    syntax_is_bad=1
-else
-    echo "OK: $file looks valid"
+  echo "### Checking if the catalog compiles"
+  puppet apply --noop manifests/site.pp
+  if [[ $? -ne 0 ]]
+  then
+      echo "ERROR: puppet catalog compilation failed"
+      syntax_is_bad=1
+  else
+      echo "OK: $file looks valid"
+  fi
 fi
 
 echo "### Checking if ruby template syntax is valid ###"


### PR DESCRIPTION
If manifests/site.pp does not exist, the pre-commit hook would always fail. This is always the case when developing puppet modules, so there should be no error if there is no catalog to compile.
