### PR TITLE
Add EPP & ruby parser validate/syntax check

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -122,6 +122,23 @@ do
 done
 echo ""
 
+echo "### Checking if puppet EPP templates are valid ###"
+for file in `git diff --name-only --cached | grep -E '\.(epp)'`
+do
+    if [[ -f $file && $file == *.epp ]]
+    then
+        $path_to_puppet epp validate $file
+        if [[ $? -ne 0 ]]
+        then
+            echo "ERROR: puppet EPP parser failed at: $file"
+            syntax_is_bad=1
+        else
+            echo "OK: $file looks valid"
+        fi
+    fi
+done
+echo ""
+
 if [[ ! -z `git diff --name-only --cached | grep -E manifests/site.pp` ]]
 then
   echo "### Checking if the catalog compiles"
@@ -149,6 +166,23 @@ do
             echo "OK: $file looks like a valid ruby template"
         fi
     fi
+done
+echo ""
+
+echo "### Checking if ruby syntax is valid ###"
+for file in `git diff --name-only --cached | grep -E '\.(rb)'`
+do
+   if [[ -f $file ]]
+   then
+       $path_to_ruby -c $file
+       if [[ $? -ne 0 ]]
+       then
+           echo "ERROR: ruby parser failed at: $file"
+           syntax_is_bad=1
+       else
+           echo "OK: $file looks like a valid ruby file"
+       fi
+   fi
 done
 echo ""
 


### PR DESCRIPTION
* add EPP (Puppet 4.x templates) via `puppet epp validate`
* add Ruby syntax checking (`ruby -c`); useful for type/provider/custom
facts in module development

I added these few additional checks for our implementation, since we started with Puppet 4.7 and did a bit of type/provider work with Puppet. It's useful to catch Ruby syntax problems at precommit

Let me know if there's any issues adding this in or if you'd rather keep this out of the original repo :)