### PR TITLE
Ensures that binary checks are not done when using the PDK

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -61,46 +61,50 @@ function prefer_pdk() {
 function setup_paths() {
   # Make sure the necessary tools are installed. If they aren't, just die and
   # stop the commit. Force the use of these tools before a commit is allowed.
-  # No commit should ever happen without a puppet-lint check.
 
-  path_to_puppet=$(command -v puppet)
-  if ! [[ -x "$path_to_puppet" ]]; then
-    echo "The puppet binary wasn't found. Sorry, I won't allow you to commit without puppet installed."
-    fail "Please install puppet and try again.\n"
-    exit 1
-  fi
-
-  path_to_puppet_lint=$(command -v puppet-lint)
-  if ! [[ -x "$path_to_puppet_lint" ]]; then
-    echo "The puppet-lint binary wasn't found. Sorry, I won't allow you to commit without puppet-lint installed."
-    fail "Please install puppet-lint and try again.\n"
-    exit 1
-  fi
-
-  path_to_erb=$(command -v erb)
-  if ! [[ -x "$path_to_erb" ]]; then
-    echo "The erb binary wasn't found. Sorry, I won't allow you to commit without erb installed."
-    fail "Please install erb (Ruby Templating) and try again.\n"
-    exit 1
-  fi
-
-  path_to_ruby=$(command -v ruby)
-  if ! [[ -x "$path_to_ruby" ]]; then
-    echo "The ruby binary wasn't found. Sorry, I won't allow you to commit without ruby installed."
-    fail "Please install ruby and try again.\n"
-    exit 1
-  fi
-
+  # Prefer the PDK by default
   if prefer_pdk && use_pdk; then
     path_to_puppet="${path_to_pdk} bundle exec puppet"
     path_to_puppet_lint="${path_to_pdk} bundle exec puppet-lint"
     path_to_erb="${path_to_pdk} bundle exec erb"
     path_to_ruby="${path_to_pdk} bundle exec ruby"
+
+  # Second preference is for a bundler setup
   elif use_bundle; then
     path_to_puppet="${path_to_bundle} exec puppet"
     path_to_puppet_lint="${path_to_bundle} exec puppet-lint"
     path_to_erb="${path_to_bundle} exec erb"
     path_to_ruby="${path_to_bundle} exec ruby"
+
+  # If neither the PDK or bundler are available, rely on actual binaries
+  else
+    path_to_puppet=$(command -v puppet)
+    if ! [[ -x "$path_to_puppet" ]]; then
+      echo "The puppet binary wasn't found. Sorry, I won't allow you to commit without puppet installed."
+      fail "Please install puppet and try again.\n"
+      exit 1
+    fi
+
+    path_to_puppet_lint=$(command -v puppet-lint)
+    if ! [[ -x "$path_to_puppet_lint" ]]; then
+      echo "The puppet-lint binary wasn't found. Sorry, I won't allow you to commit without puppet-lint installed."
+      fail "Please install puppet-lint and try again.\n"
+      exit 1
+    fi
+
+    path_to_erb=$(command -v erb)
+    if ! [[ -x "$path_to_erb" ]]; then
+      echo "The erb binary wasn't found. Sorry, I won't allow you to commit without erb installed."
+      fail "Please install erb (Ruby Templating) and try again.\n"
+      exit 1
+    fi
+
+    path_to_ruby=$(command -v ruby)
+    if ! [[ -x "$path_to_ruby" ]]; then
+      echo "The ruby binary wasn't found. Sorry, I won't allow you to commit without ruby installed."
+      fail "Please install ruby and try again.\n"
+      exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION
Caused failure when puppet-lint was not installed, even when using the PDK