### PR TITLE
Bugfix: PIPESTATUS index wrong for erb check

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -186,7 +186,7 @@ if [[ $(git diff --name-only --cached | grep -E '\.(erb)') ]]; then
   for file in $(git diff --name-only --cached | grep -E '\.(erb)'); do
     if [[ -f $file ]]; then
       $path_to_erb -P -x -T '-' $file | $path_to_ruby -c | grep -v '^Syntax OK'
-      if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+      if [[ "${PIPESTATUS[1]}" -ne 0 ]]; then
         fail "FAILED: "; echo "$file"
         syntax_is_bad=1
       else


### PR DESCRIPTION
Needed to check the exit code of the second command in the chain ($path_to_ruby -c)