### PR TITLE
Limit yaml file extension to yaml and yml

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -211,9 +211,9 @@ if [[ $(git diff --name-only --cached | grep -E '\.(rb)') ]]; then
   done
 fi
 
-if [[ $(git diff --name-only --cached | grep -E '\.(yaml)') ]]; then
+if [[ $(git diff --name-only --cached | grep -E '\.(yaml$|yml$)') ]]; then
   header "*** Checking YAML syntax ***"
-  for file in $(git diff --name-only --cached | grep -E '\.(yaml)'); do
+  for file in $(git diff --name-only --cached | grep -E '\.(yaml$|yml$)'); do
     if [[ -f $file ]]; then
       checkyaml $file
       if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Hi,

If you have a file named example.yaml.erb this will both be parsed by the ERB and YAML checks, the YAML check then fails:

=====================================
*** Checking ruby template(erb) syntax ***
PASSED: bareos/templates/host_config_generator.yaml.erb

*** Checking YAML syntax ***
Traceback (most recent call last):
	7: from -e:1:in `<main>'
	6: from /usr/share/ruby/psych.rb:497:in `load_file'
	5: from /usr/share/ruby/psych.rb:497:in `open'
	4: from /usr/share/ruby/psych.rb:498:in `block in load_file'
	3: from /usr/share/ruby/psych.rb:263:in `load'
	2: from /usr/share/ruby/psych.rb:350:in `parse'
	1: from /usr/share/ruby/psych.rb:402:in `parse_stream'
/usr/share/ruby/psych.rb:402:in `parse': (bareos/templates/host_config_generator.yaml.erb): mapping values are not allowed in this context at line 3 column 11 (Psych::SyntaxError)
FAILED: bareos/templates/host_config_generator.yaml.erb

Errors Found, Commit REJECTED
=====================================

This commit terminates the extensions and adds support for yml file extension