### PR TITLE
if prefer_pdk and pdk version >= 1.9, use the pdk to validate yaml files

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -45,6 +45,7 @@ function use_pdk() {
     path_to_pdk='powershell.exe -command pdk'
   fi
   if [[ -n "$path_to_pdk" ]]; then
+    pdk_version=$(${path_to_pdk} --version)
     return 0
   else
     return 1
@@ -113,7 +114,11 @@ function setup_paths() {
 }
 
 function checkyaml() {
-  $path_to_ruby -e "require 'yaml'; YAML.load_file('$1')"
+  if [ -n "$path_to_pdk" ] && { [ $(cut -d. -f1 <<<$pdk_version) -gt 1 ] || [ $(cut -d. -f2 <<<$pdk_version) -ge 9 ]; }; then
+    $path_to_pdk validate yaml "$1"
+  else
+    $path_to_ruby -e "require 'yaml'; YAML.load_file('$1')"
+  fi
 }
 
 setup_paths


### PR DESCRIPTION
pdk 1.9 adds support to validate yaml. This was the simplest version comparison method i could come up with to get the job done.