### PR TITLE
Make script work inside Visual Studio Code

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -20,9 +20,16 @@
 c_fail='1'  # red
 c_pass='2'  # green
 
-function header() { tput bold; echo -e "\n${1}"; tput sgr0; }
-function fail() { tput setaf $c_fail; echo -ne "${1}"; tput sgr0; }
-function pass() { tput setaf $c_pass; echo -ne "${1}"; tput sgr0; }
+if [ "${TERM}" -ne "" ]; then
+    function header() { tput bold; echo -e "\n${1}"; tput sgr0; }
+    function fail() { tput setaf $c_fail; echo -ne "${1}"; tput sgr0; }
+    function pass() { tput setaf $c_pass; echo -ne "${1}"; tput sgr0; }
+else
+    function header() { echo -e "\n${1}"; }
+    function fail() { echo -ne "${1}"; }
+    function pass() { echo -ne "${1}"; }
+fi
+
 
 function use_bundle() {
   path_to_bundle=$(command -v bundle)

--- a/pre-commit
+++ b/pre-commit
@@ -21,7 +21,7 @@
 c_fail='1'  # red
 c_pass='2'  # green
 
-if [ -n "${TERM}" ]; then
+if [ -n "${TERM}" ] && [ "${TERM}" != "dumb" ]; then
     function header() { tput bold; echo -e "\n${1}"; tput sgr0; }
     function fail() { tput setaf $c_fail; echo -ne "${1}"; tput sgr0; }
     function pass() { tput setaf $c_pass; echo -ne "${1}"; tput sgr0; }

--- a/pre-commit
+++ b/pre-commit
@@ -39,7 +39,7 @@ function use_bundle() {
 }
 
 function use_pdk() {
-  if [[ $(/usr/bin/uname -s) = 'Linux' ]] || [[ $(/usr/bin/uname -s) = 'Darwin' ]]; then
+  if [[ $(/usr/bin/env uname -s) = 'Linux' ]] || [[ $(/usr/bin/env uname -s) = 'Darwin' ]]; then
     path_to_pdk=$(command -v pdk)
   elif which powershell.exe 2>&1 >/dev/null; then
     path_to_pdk='powershell.exe -command pdk'

--- a/pre-commit
+++ b/pre-commit
@@ -15,6 +15,7 @@
 #  Mattias Geniar <m@ttias.be>
 #  Rob Nelson <rnelson0@gmail.com>
 #  Jake Rogers <code@supportoss.org>
+#  Geoff Davis <geoff@geoffdavis.com>
 
 # set colors
 c_fail='1'  # red

--- a/pre-commit
+++ b/pre-commit
@@ -21,7 +21,7 @@
 c_fail='1'  # red
 c_pass='2'  # green
 
-if [ "${TERM}" -ne "" ]; then
+if [ -n "${TERM}" ]; then
     function header() { tput bold; echo -e "\n${1}"; tput sgr0; }
     function fail() { tput setaf $c_fail; echo -ne "${1}"; tput sgr0; }
     function pass() { tput setaf $c_pass; echo -ne "${1}"; tput sgr0; }


### PR DESCRIPTION
This PR fixes several issues that caused the script to exit with a non-zero status code even though all of the checks passed.

Namely: 

1. `uname` isn't in /usr/bin on the devcontainer that Puppet manages for PDK.
2. `tput` errors out if it's not running in an interactive console.